### PR TITLE
Added a command that can be used to validate the config

### DIFF
--- a/src/App/Console/Commands/ValidateConfigCommand.php
+++ b/src/App/Console/Commands/ValidateConfigCommand.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace AshAllenDesign\ConfigValidator\App\Console\Commands;
+
+use AshAllenDesign\ConfigValidator\App\Exceptions\InvalidConfigValueException;
+use AshAllenDesign\ConfigValidator\App\Services\ConfigValidator;
+use Illuminate\Console\Command;
+
+class ValidateConfigCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'config:validate';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Validate the application config.';
+
+    /**
+     * @var ConfigValidator
+     */
+    private $configValidator;
+
+    /**
+     * Create a new command instance.
+     *
+     * @param  ConfigValidator  $configValidator
+     */
+    public function __construct(ConfigValidator $configValidator)
+    {
+        parent::__construct();
+
+        $this->configValidator = $configValidator;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->info('Validating config...');
+
+        try {
+            $this->configValidator->run();
+        } catch (InvalidConfigValueException $exception) {
+            $this->error('Config validation failed!');
+            $this->error($exception->getMessage());
+        }
+
+        $this->info('Config validation passed!');
+    }
+}

--- a/src/App/Providers/ConfigValidatorProvider.php
+++ b/src/App/Providers/ConfigValidatorProvider.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\ConfigValidator\App\Providers;
 
+use AshAllenDesign\ConfigValidator\App\Console\Commands\ValidateConfigCommand;
 use Illuminate\Support\ServiceProvider;
 
 class ConfigValidatorProvider extends ServiceProvider
@@ -23,5 +24,10 @@ class ConfigValidatorProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                ValidateConfigCommand::class,
+            ]);
+        }
     }
 }


### PR DESCRIPTION
This PR adds a new command (``` php artisan config:validate ```) that can be used for validating the system config.

Issue: #3 