### PR TITLE
Added the functionality to toggle exceptions

### DIFF
--- a/src/Services/ConfigValidator.php
+++ b/src/Services/ConfigValidator.php
@@ -29,6 +29,14 @@ class ConfigValidator
     private $errors = [];
 
     /**
+     * Specifies whether if an exception should be thrown
+     * if the config validation fails.
+     *
+     * @var bool
+     */
+    private $throwExceptionOnFailure = true;
+
+    /**
      * ConfigValidator constructor.
      *
      * @param  ValidationRepository|null  $validationRepository
@@ -46,6 +54,20 @@ class ConfigValidator
     public function errors(): array
     {
         return $this->errors;
+    }
+
+    /**
+     * Determine whether an exception should be thrown if
+     * the validation fails.
+     *
+     * @param  bool  $throwException
+     * @return ConfigValidator
+     */
+    public function throwExceptionOnFailure(bool $throwException = true): self
+    {
+        $this->throwExceptionOnFailure = $throwException;
+
+        return $this;
     }
 
     /**
@@ -74,7 +96,10 @@ class ConfigValidator
 
     /**
      * Validate the config values against the config rules
-     * that have been set.
+     * that have been set. If throwExceptionOnFailure is
+     * set to true, the validator's first error message
+     * will be used as the message in the thrown
+     * exception.
      *
      * @return bool
      * @throws InvalidConfigValueException
@@ -88,7 +113,11 @@ class ConfigValidator
         if ($validator->fails()) {
             $this->errors = $validator->errors()->messages();
 
-            throw new InvalidConfigValueException($validator->errors()->first());
+            if ($this->throwExceptionOnFailure) {
+                throw new InvalidConfigValueException($validator->errors()->first());
+            }
+
+            return false;
         }
 
         return true;

--- a/tests/Unit/Services/ConfigValidator/RunTest.php
+++ b/tests/Unit/Services/ConfigValidator/RunTest.php
@@ -93,7 +93,7 @@ class RunTest extends TestCase
         File::put(config_path('validation/mail.php'), file_get_contents($stubFilePath));
 
         $configValidator = new ConfigValidator();
-        $configValidator->run();
+        $configValidator->throwExceptionOnFailure(true)->run();
     }
 
     /** @test */
@@ -176,6 +176,21 @@ class RunTest extends TestCase
                 'The mail.port must be an integer.',
             ],
         ], $configValidator->errors());
+    }
+
+    /** @test */
+    public function exception_is_not_thrown_if_it_is_disabled_before_running_the_validator()
+    {
+        // Set invalid config values that will have their error messages stored.
+        Config::set('cache.default', null);
+
+        $cacheStubFilePath = __DIR__.'/../../Stubs/cache.php';
+
+        File::makeDirectory(config_path('validation'));
+        File::put(config_path('validation/cache.php'), file_get_contents($cacheStubFilePath));
+
+        $configValidator = new ConfigValidator();
+        $this->assertFalse($configValidator->throwExceptionOnFailure(false)->run());
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This PR adds a new ``` throwExceptionOnFailure() ``` method that we can use to toggle whether if exceptions are thrown when the validator fails.