### PR TITLE
feat: Improve validation error styling with `Termwind`.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "php": "^8.0",
     "illuminate/container": "^8.0|^9.0",
     "illuminate/cache": "^8.0|^9.0",
-    "ext-json": "*"
+    "ext-json": "*",
+    "nunomaduro/termwind": "^1.6"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",

--- a/resources/views/validate-config.blade.php
+++ b/resources/views/validate-config.blade.php
@@ -1,0 +1,25 @@
+<div class="my-1 mx-2">
+    <div class="bg-red-700 text-white font-bold px-1 mb-1">Config validation failed!</div>
+
+    <div class="mb-1"><b>{{ count($allErrors) }} errors</b> found on your application:</div>
+    <div class="space-y-1">
+        @foreach ($allErrors as $configField => $errors)
+            <div>
+                <div>
+                    <span class="text-yellow font-bold">{{ $configField }}</span>
+                    <span class="ml-2">
+                        Value:
+                        @if (config($configField))
+                            <b>{{ config($configField) }}</b>
+                        @else
+                            <i class="text-gray-400">[empty field]</i>
+                        @endif
+                    </span>
+                </div>
+                @foreach ($errors as $error)
+                    <div class="ml-2 text-gray-500">⇁ {{ $error }}</div>
+                @endforeach
+            </div>
+        @endforeach
+    </div>
+</div>

--- a/src/Console/Commands/ValidateConfigCommand.php
+++ b/src/Console/Commands/ValidateConfigCommand.php
@@ -9,7 +9,8 @@ use AshAllenDesign\ConfigValidator\Services\ConfigValidator;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Output\ConsoleOutput;
-use function Termwind\{render, renderUsing};
+use function Termwind\render;
+use function Termwind\renderUsing;
 
 class ValidateConfigCommand extends Command
 {
@@ -65,7 +66,7 @@ class ValidateConfigCommand extends Command
             renderUsing($output);
         }
 
-        render(<<<HTML
+        render(<<<'HTML'
             <div class="my-1 mx-2">
                 Validating config...
             </div>
@@ -85,7 +86,7 @@ class ValidateConfigCommand extends Command
             return self::FAILURE;
         }
 
-        render(<<<HTML
+        render(<<<'HTML'
             <div class="my-1 mx-2 bg-green text-black px-1 font-bold">
                 Config validation passed!
             </div>

--- a/src/Providers/ConfigValidatorProvider.php
+++ b/src/Providers/ConfigValidatorProvider.php
@@ -32,6 +32,8 @@ class ConfigValidatorProvider extends ServiceProvider
         ], 'config-validator-defaults');
 
         if ($this->app->runningInConsole()) {
+            $this->loadViewsFrom(__DIR__.'/../../resources/views', 'config-validator');
+
             $this->commands([
                 ValidateConfigCommand::class,
                 ValidationMakeCommand::class,

--- a/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
+++ b/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
@@ -7,9 +7,18 @@ use AshAllenDesign\ConfigValidator\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Output\BufferedOutput;
+use function Termwind\renderUsing;
 
 class HandleTest extends TestCase
 {
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        renderUsing(new BufferedOutput());
+    }
+
     /** @test */
     public function command_can_be_run()
     {
@@ -19,7 +28,7 @@ class HandleTest extends TestCase
         $this->createMockValidationFile();
 
         Artisan::call('config:validate');
-        $this->assertEquals("Validating config...\nConfig validation passed!\n", Artisan::output());
+        $this->assertStringContainsString(Artisan::output(), 'Config validation passed!');
     }
 
     /** @test */
@@ -32,7 +41,7 @@ class HandleTest extends TestCase
         });
 
         Artisan::call('config:validate --path=hello');
-        $this->assertEquals("Validating config...\nConfig validation passed!\n", Artisan::output());
+        $this->assertStringContainsString(Artisan::output(), 'Config validation passed!');
     }
 
     /** @test */
@@ -45,7 +54,7 @@ class HandleTest extends TestCase
         });
 
         Artisan::call('config:validate --files=auth,mail,telescope');
-        $this->assertEquals("Validating config...\nConfig validation passed!\n", Artisan::output());
+        $this->assertStringContainsString(Artisan::output(), 'Config validation passed!');
     }
 
     private function createMockValidationFile()


### PR DESCRIPTION
This PR adds an improvement to the output command `php artisan config:validate`.

<img width="967" alt="image" src="https://user-images.githubusercontent.com/823088/160263848-6ecc0bd8-90af-4fee-90fd-9e495fb62347.png">

Let me know what do you think.

PS: Found an issue that I did not look for it on this PR, on the error description looks like the "_" are missing from the configField.