### PR TITLE
Removed illuminate/cache and required illuminate/command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
   ],
   "require": {
     "php": "^8.0",
+    "illuminate/console": "^8.0|^9.0",
     "illuminate/container": "^8.0|^9.0",
-    "illuminate/cache": "^8.0|^9.0",
-    "ext-json": "*",
-    "nunomaduro/termwind": "^1.6"
+    "nunomaduro/termwind": "^1.6",
+    "ext-json": "*"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",


### PR DESCRIPTION
The `composer.json` file contained a requirement for `illuminate/cache`. However, this package doesn't interact with the cache, so it's not needed.

I've also added a requirement for the `illuminate/command` package because we directly interact with Laravel commands.