### PR TITLE
Display Termwind errors if other package exceptions are thrown

### DIFF
--- a/resources/views/validate-config.blade.php
+++ b/resources/views/validate-config.blade.php
@@ -1,7 +1,7 @@
 <div class="my-1 mx-2">
     <div class="bg-red-700 text-white font-bold px-1 mb-1">Config validation failed!</div>
 
-    <div class="mb-1"><b>{{ count($allErrors) }} errors</b> found on your application:</div>
+    <div class="mb-1"><b>{{ count($allErrors) }} errors</b> found in your application:</div>
     <div class="space-y-1">
         @foreach ($allErrors as $configField => $errors)
             <div>
@@ -17,7 +17,7 @@
                     </span>
                 </div>
                 @foreach ($errors as $error)
-                    <div class="ml-2 text-gray-500">⇁ {{ $error }}</div>
+                    <div class="ml-2 text-gray-500">- {{ $error }}</div>
                 @endforeach
             </div>
         @endforeach

--- a/src/Console/Commands/ValidateConfigCommand.php
+++ b/src/Console/Commands/ValidateConfigCommand.php
@@ -60,23 +60,15 @@ class ValidateConfigCommand extends Command
      */
     public function handle(): int
     {
-        $output = (new ConsoleOutput)->section();
+        try {
+            $this->configValidator
+                ->throwExceptionOnFailure(false)
+                ->run($this->determineFilesToValidate(), $this->option('path'));
+        } catch (DirectoryNotFoundException|NoValidationFilesFoundException $exception) {
+            $this->displayErrorMessage($exception->getMessage());
 
-        if ($this->laravel->environment() !== 'testing') {
-            renderUsing($output);
+            return self::FAILURE;
         }
-
-        render(<<<'HTML'
-            <div class="my-1 mx-2">
-                Validating config...
-            </div>
-        HTML);
-
-        $this->configValidator
-            ->throwExceptionOnFailure(false)
-            ->run($this->determineFilesToValidate(), $this->option('path'));
-
-        $output->clear();
 
         if (! empty($this->configValidator->errors())) {
             render(view('config-validator::validate-config', [
@@ -86,11 +78,7 @@ class ValidateConfigCommand extends Command
             return self::FAILURE;
         }
 
-        render(<<<'HTML'
-            <div class="my-1 mx-2 bg-green text-black px-1 font-bold">
-                Config validation passed!
-            </div>
-        HTML);
+        $this->displaySuccessfulValidationMessage();
 
         return self::SUCCESS;
     }
@@ -120,5 +108,21 @@ class ValidateConfigCommand extends Command
         }
 
         return $filesToValidate;
+    }
+
+    private function displaySuccessfulValidationMessage(): void
+    {
+        render(<<<'HTML'
+            <div class="my-1 mx-2 bg-green text-black px-1 font-bold">
+                Config validation passed!
+            </div>
+        HTML);
+    }
+
+    private function displayErrorMessage(string $message): void
+    {
+        render(<<<HTML
+                <div class="my-1 mx-2 bg-red-700 text-white font-bold px-1 mb-1">$message</div>
+            HTML);
     }
 }

--- a/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
+++ b/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
@@ -2,37 +2,43 @@
 
 namespace AshAllenDesign\ConfigValidator\Tests\Unit\Console\Commands\ValidateConfigCommand;
 
+use AshAllenDesign\ConfigValidator\Exceptions\DirectoryNotFoundException;
+use AshAllenDesign\ConfigValidator\Exceptions\NoValidationFilesFoundException;
 use AshAllenDesign\ConfigValidator\Services\ConfigValidator;
 use AshAllenDesign\ConfigValidator\Tests\Unit\TestCase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
+use Mockery\MockInterface;
 use Symfony\Component\Console\Output\BufferedOutput;
 use function Termwind\renderUsing;
 
 class HandleTest extends TestCase
 {
+    private BufferedOutput $output;
+
     public function setUp(): void
     {
         parent::setUp();
 
-        renderUsing(new BufferedOutput());
+        File::deleteDirectory(base_path('config-validation'));
     }
 
     /** @test */
-    public function command_can_be_run()
+    public function command_can_be_run(): void
     {
         Config::set('cache.default', 'array');
         Config::set('cache.prefix', 'foobar');
 
         $this->createMockValidationFile();
 
-        Artisan::call('config:validate');
-        $this->assertStringContainsString(Artisan::output(), 'Config validation passed!');
+        $output = $this->runCommand('config:validate');
+
+        $this->assertStringContainsString('Config validation passed!', $output);
     }
 
     /** @test */
-    public function command_can_be_run_with_the_path_option()
+    public function command_can_be_run_with_the_path_option(): void
     {
         $this->mock(ConfigValidator::class, function ($mock) {
             $mock->shouldReceive('throwExceptionOnFailure')->withArgs([false])->andReturn($mock);
@@ -40,12 +46,12 @@ class HandleTest extends TestCase
             $mock->shouldReceive('errors')->withNoArgs()->andReturn([]);
         });
 
-        Artisan::call('config:validate --path=hello');
-        $this->assertStringContainsString(Artisan::output(), 'Config validation passed!');
+        $output = $this->runCommand('config:validate --path=hello');
+        $this->assertStringContainsString('Config validation passed!', $output);
     }
 
     /** @test */
-    public function command_can_be_run_with_the_files_option()
+    public function command_can_be_run_with_the_files_option(): void
     {
         $this->mock(ConfigValidator::class, function ($mock) {
             $mock->shouldReceive('throwExceptionOnFailure')->withArgs([false])->andReturn($mock);
@@ -53,13 +59,86 @@ class HandleTest extends TestCase
             $mock->shouldReceive('errors')->withNoArgs()->andReturn([]);
         });
 
-        Artisan::call('config:validate --files=auth,mail,telescope');
-        $this->assertStringContainsString(Artisan::output(), 'Config validation passed!');
+        $output = $this->runCommand('config:validate --files=auth,mail,telescope');
+
+        $this->assertStringContainsString('Config validation passed!', $output);
     }
 
-    private function createMockValidationFile()
+    /** @test */
+    public function error_is_displayed_if_a_config_validation_fails(): void
     {
-        $stubFilePath = __DIR__.'/../../../Stubs/cache.php';
+        $this->mock(ConfigValidator::class, function ($mock) {
+            $mock->shouldReceive('throwExceptionOnFailure')->withArgs([false])->andReturn($mock);
+            $mock->shouldReceive('run')->withArgs([['auth', 'mail', 'telescope'], null]);
+            $mock->shouldReceive('errors')->withNoArgs()->andReturn([
+                'cache.default' => [
+                    'The cache.default must be a string.',
+                    'The cache.default field is required.',
+                ],
+                'cache.prefix' => [
+                    'The cache.prefix must be equal to foobar.',
+                ],
+                'mail.port' => [
+                    'The mail.port must be an integer.',
+                ],
+            ]);
+        });
+
+        $output = $this->runCommand('config:validate --files=auth,mail,telescope');
+
+        $this->assertStringContainsString('Config validation failed!', $output);
+        $this->assertStringContainsString('3 errors found in your application:', $output);
+
+        $this->assertStringContainsString('cache.default', $output);
+        $this->assertStringContainsString('The cache.default must be a string.', $output);
+        $this->assertStringContainsString('The cache.default field is required.', $output);
+
+        $this->assertStringContainsString('cache.prefix', $output);
+        $this->assertStringContainsString('The cache.prefix must be equal to foobar.', $output);
+
+        $this->assertStringContainsString('mail.port', $output);
+        $this->assertStringContainsString('The mail.port must be an integer.', $output);
+    }
+
+    /** @test */
+    public function error_is_displayed_if_a_directory_does_not_exist(): void
+    {
+        $this->mock(ConfigValidator::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('throwExceptionOnFailure')
+                ->withArgs([false])
+                ->andReturn($mock);
+
+            $mock->shouldReceive('run')
+                ->withArgs([[], null])
+                ->andThrow(new DirectoryNotFoundException('The directory does not exist.'));
+        });
+
+        $output = $this->runCommand('config:validate');
+
+        $this->assertStringContainsString('The directory does not exist.', $output);
+    }
+
+    /** @test */
+    public function error_is_displayed_if_a_directory_is_empty(): void
+    {
+        $this->mock(ConfigValidator::class, function (MockInterface $mock): void {
+            $mock->shouldReceive('throwExceptionOnFailure')
+                ->withArgs([false])
+                ->andReturn($mock);
+
+            $mock->shouldReceive('run')
+                ->withArgs([[], null])
+                ->andThrow(new NoValidationFilesFoundException('The directory does not contain any validation files.'));
+        });
+
+        $output = $this->runCommand('config:validate');
+
+        $this->assertStringContainsString('The directory does not contain any validation files.', $output);
+    }
+
+    private function createMockValidationFile(): void
+    {
+        $stubFilePath = __DIR__ . '/../../../Stubs/cache.php';
 
         File::makeDirectory(base_path('config-validation'));
         File::put(base_path('config-validation/cache.php'), file_get_contents($stubFilePath));
@@ -70,5 +149,15 @@ class HandleTest extends TestCase
         File::deleteDirectory(base_path('config-validation'));
 
         parent::tearDown();
+    }
+
+    private function runCommand(string $command): string
+    {
+        $output = new BufferedOutput();
+        renderUsing($output);
+
+        Artisan::call($command);
+
+        return $output->fetch();
     }
 }


### PR DESCRIPTION
This PR updates the command to now catch any other package exceptions that are thrown and display them nicely using Termwind.