### PR TITLE
Fixed bug that threw an error if the failed config field was an array

### DIFF
--- a/resources/views/validate-config.blade.php
+++ b/resources/views/validate-config.blade.php
@@ -10,7 +10,11 @@
                     <span class="ml-2">
                         Value:
                         @if (config($configField))
-                            <b>{{ config($configField) }}</b>
+                            @if(is_array(config($configField)))
+                                <b>{{ json_encode(config($configField, JSON_PRETTY_PRINT)) }}</b>
+                            @else
+                                <b>{{ config($configField) }}</b>
+                            @endif
                         @else
                             <i class="text-gray-400">[empty field]</i>
                         @endif

--- a/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
+++ b/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
@@ -67,7 +67,7 @@ class HandleTest extends TestCase
     /** @test */
     public function error_is_displayed_if_a_config_validation_fails(): void
     {
-        Config::set('cache.default', ['invalid', 'items', 'in', 'an', 'array']);
+        Config::set('cache.field', ['invalid', 'items', 'in', 'an', 'array']);
 
         Config::set('mail.port', [
             'assoc' => 'array',
@@ -78,9 +78,9 @@ class HandleTest extends TestCase
             $mock->shouldReceive('throwExceptionOnFailure')->withArgs([false])->andReturn($mock);
             $mock->shouldReceive('run')->withArgs([['auth', 'mail', 'telescope'], null]);
             $mock->shouldReceive('errors')->withNoArgs()->andReturn([
-                'cache.default' => [
-                    'The cache.default must be a string.',
-                    'The cache.default field is required.',
+                'cache.field' => [
+                    'The cache.field must be a string.',
+                    'The cache.field field is required.',
                 ],
                 'cache.prefix' => [
                     'The cache.prefix must be equal to foobar.',
@@ -99,10 +99,10 @@ class HandleTest extends TestCase
         $this->assertStringContainsString('Config validation failed!', $output);
         $this->assertStringContainsString('4 errors found in your application:', $output);
 
-        $this->assertStringContainsString('cache.default', $output);
+        $this->assertStringContainsString('cache.field', $output);
         $this->assertStringContainsString('["invalid","items","in","an","array"]', $output);
-        $this->assertStringContainsString('The cache.default must be a string.', $output);
-        $this->assertStringContainsString('The cache.default field is required.', $output);
+        $this->assertStringContainsString('The cache.field must be a string.', $output);
+        $this->assertStringContainsString('The cache.field field is required.', $output);
 
         $this->assertStringContainsString('cache.prefix  Value: laravel_cache_', $output);
         $this->assertStringContainsString('The cache.prefix must be equal to foobar.', $output);

--- a/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
+++ b/tests/Unit/Console/Commands/ValidateConfigCommand/HandleTest.php
@@ -104,7 +104,7 @@ class HandleTest extends TestCase
         $this->assertStringContainsString('The cache.field must be a string.', $output);
         $this->assertStringContainsString('The cache.field field is required.', $output);
 
-        $this->assertStringContainsString('cache.prefix  Value: laravel_cache_', $output);
+        $this->assertStringContainsString('cache.prefix  Value: laravel_cache', $output);
         $this->assertStringContainsString('The cache.prefix must be equal to foobar.', $output);
 
         $this->assertStringContainsString('mail.port', $output);


### PR DESCRIPTION
Closes: https://github.com/ash-jc-allen/laravel-config-validator/issues/47