### PR TITLE
Check for missing validations

### DIFF
--- a/resources/views/validate-config.blade.php
+++ b/resources/views/validate-config.blade.php
@@ -19,6 +19,21 @@
                             <i class="text-gray-400">[empty field]</i>
                         @endif
                     </span>
+
+                </div>
+                @foreach ($errors as $error)
+                    <div class="ml-2 text-gray-500">- {{ $error }}</div>
+                @endforeach
+            </div>
+        @endforeach
+    </div>
+
+    <div class="mb-1"><b>{{ count($allMissing) }} Missing </b> found in your application:</div>
+    <div class="space-y-1">
+        @foreach ($allMissing as $configField => $errors)
+            <div>
+                <div>
+                    <span class="text-yellow font-bold">{{ $configField }}</span>
                 </div>
                 @foreach ($errors as $error)
                     <div class="ml-2 text-gray-500">- {{ $error }}</div>

--- a/src/Console/Commands/ValidateConfigCommand.php
+++ b/src/Console/Commands/ValidateConfigCommand.php
@@ -68,10 +68,9 @@ class ValidateConfigCommand extends Command
      */
     public function handle(): int
     {
-        if (!$this->option('skip-missing')) {
+        if (! $this->option('skip-missing')) {
             $this->configLocalValidator->run();
         }
-
 
         try {
             $this->configValidator

--- a/src/Services/BaseValidator.php
+++ b/src/Services/BaseValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AshAllenDesign\ConfigValidator\Services;
+
+use AshAllenDesign\ConfigValidator\Traits\LoadsConfigValidationFiles;
+
+abstract class BaseValidator
+{
+    use LoadsConfigValidationFiles;
+
+    /**
+     * The repository that holds the config values being
+     * validated, along with the rules and messages
+     * used for running the validation.
+     *
+     * @var ValidationRepository
+     */
+    protected ValidationRepository $validationRepository;
+
+    /**
+     * An array of the validation error messages.
+     *
+     * @var array
+     */
+    protected array $errors = [];
+
+    /**
+     * ConfigValidator constructor.
+     *
+     * @param  ValidationRepository|null  $validationRepository
+     */
+    public function __construct(ValidationRepository $validationRepository = null)
+    {
+        $this->validationRepository = $validationRepository ?? new ValidationRepository();
+    }
+
+    public abstract function run(array $configFiles = [], string $validationFolderPath = null): bool;
+
+    /**
+     * Return the validation error messages.
+     *
+     * @return array
+     */
+    public function errors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/src/Services/BaseValidator.php
+++ b/src/Services/BaseValidator.php
@@ -27,7 +27,7 @@ abstract class BaseValidator
     /**
      * ConfigValidator constructor.
      *
-     * @param ValidationRepository|null $validationRepository
+     * @param  ValidationRepository|null  $validationRepository
      */
     public function __construct(ValidationRepository $validationRepository = null)
     {

--- a/src/Services/BaseValidator.php
+++ b/src/Services/BaseValidator.php
@@ -27,7 +27,7 @@ abstract class BaseValidator
     /**
      * ConfigValidator constructor.
      *
-     * @param  ValidationRepository|null  $validationRepository
+     * @param ValidationRepository|null $validationRepository
      */
     public function __construct(ValidationRepository $validationRepository = null)
     {

--- a/src/Services/BaseValidator.php
+++ b/src/Services/BaseValidator.php
@@ -34,7 +34,7 @@ abstract class BaseValidator
         $this->validationRepository = $validationRepository ?? new ValidationRepository();
     }
 
-    public abstract function run(array $configFiles = [], string $validationFolderPath = null): bool;
+    abstract public function run(array $configFiles = [], string $validationFolderPath = null): bool;
 
     /**
      * Return the validation error messages.

--- a/src/Services/ConfigValidator.php
+++ b/src/Services/ConfigValidator.php
@@ -5,29 +5,10 @@ namespace AshAllenDesign\ConfigValidator\Services;
 use AshAllenDesign\ConfigValidator\Exceptions\DirectoryNotFoundException;
 use AshAllenDesign\ConfigValidator\Exceptions\InvalidConfigValueException;
 use AshAllenDesign\ConfigValidator\Exceptions\NoValidationFilesFoundException;
-use AshAllenDesign\ConfigValidator\Traits\LoadsConfigValidationFiles;
 use Illuminate\Support\Facades\Validator;
 
-class ConfigValidator
+class ConfigValidator extends BaseValidator
 {
-    use LoadsConfigValidationFiles;
-
-    /**
-     * The repository that holds the config values being
-     * validated, along with the rules and messages
-     * used for running the validation.
-     *
-     * @var ValidationRepository
-     */
-    private ValidationRepository $validationRepository;
-
-    /**
-     * An array of the validation error messages.
-     *
-     * @var array
-     */
-    private array $errors = [];
-
     /**
      * Specifies whether if an exception should be thrown
      * if the config validation fails.
@@ -35,26 +16,6 @@ class ConfigValidator
      * @var bool
      */
     private bool $throwExceptionOnFailure = true;
-
-    /**
-     * ConfigValidator constructor.
-     *
-     * @param  ValidationRepository|null  $validationRepository
-     */
-    public function __construct(ValidationRepository $validationRepository = null)
-    {
-        $this->validationRepository = $validationRepository ?? new ValidationRepository();
-    }
-
-    /**
-     * Return the validation error messages.
-     *
-     * @return array
-     */
-    public function errors(): array
-    {
-        return $this->errors;
-    }
 
     /**
      * Determine whether an exception should be thrown if

--- a/src/Services/LocalConfigValidator.php
+++ b/src/Services/LocalConfigValidator.php
@@ -19,7 +19,7 @@ class LocalConfigValidator extends BaseValidator
             $this->errors[$value][] = 'No validation rule specified';
         }
 
-        if (!empty($this->errors)) {
+        if (! empty($this->errors)) {
             return false;
         }
 

--- a/src/Services/LocalConfigValidator.php
+++ b/src/Services/LocalConfigValidator.php
@@ -19,7 +19,7 @@ class LocalConfigValidator extends BaseValidator
             $this->errors[$value][] = 'No validation rule specified';
         }
 
-        if (!empty($this->errors)) {
+        if (! empty($this->errors)) {
             return false;
         }
 
@@ -68,7 +68,7 @@ class LocalConfigValidator extends BaseValidator
 
             // restore the array element
             array_pop($explodedKey);
-            if (0 === (int)$lastElementInKey) {
+            if (0 === (int) $lastElementInKey) {
                 $processedKeys[] = implode('.', $explodedKey);      // adds: config.value
             }
         }

--- a/src/Services/LocalConfigValidator.php
+++ b/src/Services/LocalConfigValidator.php
@@ -19,7 +19,7 @@ class LocalConfigValidator extends BaseValidator
             $this->errors[$value][] = 'No validation rule specified';
         }
 
-        if (! empty($this->errors)) {
+        if (!empty($this->errors)) {
             return false;
         }
 
@@ -29,6 +29,7 @@ class LocalConfigValidator extends BaseValidator
     private function getCleanLocalConfigKeys(): array
     {
         $localKeys = $this->getAllLocalConfigKeys();
+
         return $this->removeKeysEndingOnIntegers($localKeys);
     }
 
@@ -41,7 +42,6 @@ class LocalConfigValidator extends BaseValidator
             $localConfig = require $path;
 
             $allLocalConfigs[$key] = $localConfig;
-
         }
 
         return array_keys(Arr::dot($allLocalConfigs));
@@ -68,14 +68,13 @@ class LocalConfigValidator extends BaseValidator
 
             // restore the array element
             array_pop($explodedKey);
-            if (0 === (int) $lastElementInKey) {
+            if (0 === (int)$lastElementInKey) {
                 $processedKeys[] = implode('.', $explodedKey);      // adds: config.value
             }
         }
 
         return $processedKeys;
     }
-
 
     public function validationArray(array $configFiles = [], string $validationFolderPath = null)
     {

--- a/src/Services/LocalConfigValidator.php
+++ b/src/Services/LocalConfigValidator.php
@@ -68,7 +68,7 @@ class LocalConfigValidator extends BaseValidator
 
             // restore the array element
             array_pop($explodedKey);
-            if (0 === (int)$lastElementInKey) {
+            if (0 === (int) $lastElementInKey) {
                 $processedKeys[] = implode('.', $explodedKey);      // adds: config.value
             }
         }

--- a/src/Services/LocalConfigValidator.php
+++ b/src/Services/LocalConfigValidator.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace AshAllenDesign\ConfigValidator\Services;
+
+use Illuminate\Support\Arr;
+
+class LocalConfigValidator extends BaseValidator
+{
+    public function run(array $configFiles = [], string $validationFolderPath = null): bool
+    {
+        $localKeys = $this->getCleanLocalConfigKeys();
+
+        $ruleKeys = $this->validationArray();
+
+        // get the local keys that are not defined in the rules.
+        $missing = array_diff($localKeys, $ruleKeys);
+
+        foreach ($missing as $value) {
+            $this->errors[$value][] = 'No validation rule specified';
+        }
+
+        if (!empty($this->errors)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getCleanLocalConfigKeys(): array
+    {
+        $localKeys = $this->getAllLocalConfigKeys();
+        return $this->removeKeysEndingOnIntegers($localKeys);
+    }
+
+    private function getAllLocalConfigKeys(): array
+    {
+        $localConfigFiles = $this->getValidationFiles([], '/config');
+
+        $allLocalConfigs = [];
+        foreach ($localConfigFiles as $key => $path) {
+            $localConfig = require $path;
+
+            $allLocalConfigs[$key] = $localConfig;
+
+        }
+
+        return array_keys(Arr::dot($allLocalConfigs));
+    }
+
+    private function removeKeysEndingOnIntegers(array $rawKeys): array
+    {
+        foreach ($rawKeys as $key => $value) {
+            $rawKeys = $this->convertNumericEnding($value, $rawKeys, $key);
+        }
+
+        return $rawKeys;
+    }
+
+    private function convertNumericEnding(string $key, array $rawKeys, int $index): array
+    {
+        $processedKeys = $rawKeys;
+
+        $explodedKey = explode('.', $key);
+        $lastElementInKey = end($explodedKey);
+
+        if (is_numeric($lastElementInKey)) {
+            unset($processedKeys[$index]);      // removes : config.value.0 ; config.value.1
+
+            // restore the array element
+            array_pop($explodedKey);
+            if (0 === (int)$lastElementInKey) {
+                $processedKeys[] = implode('.', $explodedKey);      // adds: config.value
+            }
+        }
+
+        return $processedKeys;
+    }
+
+
+    public function validationArray(array $configFiles = [], string $validationFolderPath = null)
+    {
+        $validationFiles = $this->getValidationFiles($configFiles, $validationFolderPath);
+
+        foreach ($validationFiles as $key => $path) {
+            $ruleSet = require $path;
+
+            $this->validationRepository->push($key, $ruleSet);
+        }
+
+        return array_keys($this->validationRepository->asArray()['rules']);
+    }
+}

--- a/src/Traits/LoadsConfigValidationFiles.php
+++ b/src/Traits/LoadsConfigValidationFiles.php
@@ -20,7 +20,7 @@ trait LoadsConfigValidationFiles
      * @throws DirectoryNotFoundException
      * @throws NoValidationFilesFoundException
      */
-    private function getValidationFiles(array $configFiles = [], string $validationFolderPath = null): array
+    protected function getValidationFiles(array $configFiles = [], string $validationFolderPath = null): array
     {
         $files = [];
 


### PR DESCRIPTION
Add missing config validations
User case: when I change or add certain config keys there was no check if the config validation has been updated. With this PR the keys are checked if there is a matching config validation rule

This PR add the functionality to test if all local config values have a config-validation rule. If not an error is reported.
This can be turned off with the --skip-missing flag in the command

