### PR TITLE
Fix nested config

### DIFF
--- a/src/Services/ValidationRepository.php
+++ b/src/Services/ValidationRepository.php
@@ -149,7 +149,10 @@ class ValidationRepository
         // If the config value is nested (e.g. mail.from.address) then we add
         // it differently to standard non-nested fields.
         if (is_array($hydrated[$field])) {
-            $this->configValues[$key][$field] += $hydrated[$field];
+            $this->configValues[$key][array_key_first($hydrated)] = array_merge_recursive(
+                $this->configValues[$key][$field],
+                $hydrated[$field],
+            );
         } else {
             $this->configValues[$key][array_key_first($hydrated)] = $hydrated[array_key_first($hydrated)];
         }

--- a/src/Services/ValidationRepository.php
+++ b/src/Services/ValidationRepository.php
@@ -149,7 +149,7 @@ class ValidationRepository
         // If the config value is nested (e.g. mail.from.address) then we add
         // it differently to standard non-nested fields.
         if (is_array($hydrated[$field])) {
-            $this->configValues[$key][array_key_first($hydrated)] = array_merge_recursive(
+            $this->configValues[$key][$field] = array_merge_recursive(
                 $this->configValues[$key][$field],
                 $hydrated[$field],
             );

--- a/tests/Unit/Services/ConfigValidator/RunInlineTest.php
+++ b/tests/Unit/Services/ConfigValidator/RunInlineTest.php
@@ -23,12 +23,19 @@ final class RunInlineTest extends TestCase
         Config::set('mail.port', 1234);
         Config::set('cache.prefix', 'foobar');
 
+        Config::set('short-url.tracking.fields.ip_address', true);
+        Config::set('short-url.tracking.fields.user_agent', true);
+
         $configValidator = new ConfigValidator();
 
         $this->assertTrue(
             $configValidator->runInline([
                 'mail' => $this->mailRules(),
                 'cache' => $this->cacheRules(),
+                'short-url' => [
+                    Rule::make('tracking.fields.ip_address')->rules(['required', 'boolean']),
+                    Rule::make('tracking.fields.user_agent')->rules(['required', 'boolean']),
+                ],
             ]),
         );
     }


### PR DESCRIPTION
Currently, there is a bug that prevents deep-nested config fields from being validated. This is down to the way I was reading the config files and adding their values to the `ValidationRepository`. If a field was nested more than 2 times, only the first field at that level would be added to the repository.

For example, say we have this `short-url` config field:

```php
return [
    'prefix' => 'short',

    'tracking' => [
        'fields' => [
            'ip_address' => true,
            'operating_system' => true,
        ],
    ],
];
```

In this instance, the `ValidationRepository` would only load the following values:

- `short-url.prefix`
- `short-url.tracking.fields.ip_address`

`short-url.tracking.fields.operating_system`'s value would not be loaded. This means the field couldn't be validated as expected.