### PR TITLE
Migrate from `nunomaduro/larastan` to `larastan/larastan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+**v2.7.0 (released 2024-11-30):**
+
+- Added explicit nullable types to support PHP 8.4. [#68](https://github.com/ash-jc-allen/laravel-config-validator/pull/68)
+
 **v2.6.1 (released 2024-04-26):**
 
 - Fixed a bug that prevented deep-nested config items from being validated. [#66](https://github.com/ash-jc-allen/laravel-config-validator/pull/66)

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "larastan/larastan": "^2.0|^3.0",
+        "larastan/larastan": "^1.0|^2.0|^3.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.0|^10.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "nunomaduro/larastan": "^1.0.0||^2.0.0",
+        "larastan/larastan": "^2.0|^3.0",
         "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
         "phpunit/phpunit": "^9.0|^10.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "larastan/larastan": "^1.0|^2.0|^3.0",
+        "larastan/larastan": "^1.0|^2.0",
         "orchestra/testbench": "^8.0|^9.0",
         "phpunit/phpunit": "^9.0|^10.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "mockery/mockery": "^1.0",
-        "larastan/larastan": "^1.0|^2.0",
+        "larastan/larastan": "^1.0|^2.0|^3.0",
         "orchestra/testbench": "^8.0|^9.0",
         "phpunit/phpunit": "^9.0|^10.5"
     },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,5 +8,9 @@ parameters:
 
     level: 6
 
+    reportUnmatchedIgnoredErrors: false
+
     ignoreErrors:
-        - '#Parameter \#1 \$view of function view expects view-string\|null, string given.#'
+        - '#Property AshAllenDesign\\ConfigValidator\\Services\\ValidationRepository\:\:\$rules has unknown class Illuminate\\Contracts\\Validation\\ValidationRule as its type.#'
+        - '#Property AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:\$rules has unknown class Illuminate\\Contracts\\Validation\\ValidationRule as its type.#'
+        - '#Parameter \$rules of method AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:rules\(\) has invalid type AshAllenDesign\\ConfigValidator\\Services\\ValidationRule.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,4 +13,5 @@ parameters:
     ignoreErrors:
         - '#Property AshAllenDesign\\ConfigValidator\\Services\\ValidationRepository\:\:\$rules has unknown class Illuminate\\Contracts\\Validation\\ValidationRule as its type.#'
         - '#Property AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:\$rules has unknown class Illuminate\\Contracts\\Validation\\ValidationRule as its type.#'
-        - '#Parameter \$rules of method AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:rules\(\) has invalid type AshAllenDesign\\ConfigValidator\\Services\\ValidationRule.#'
+        - '#Parameter \$rules of method AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:rules\(\) has invalid type Illuminate\\Contracts\\Validation\\ValidationRule.#'
+        - '#Method AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:getRules\(\) has invalid return type Illuminate\\Contracts\\Validation\\ValidationRule.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,4 @@ parameters:
     level: 6
 
     ignoreErrors:
-        - identifier: missingType.iterableValue
         - '#Parameter \#1 \$view of function view expects view-string\|null, string given.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,4 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:
-        - '#Parameter #1 $view of function view expects view-string|null, string given. #'
+        - '#Parameter \#1 \$view of function view expects view-string\|null, string given. #'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,11 +7,3 @@ parameters:
         - src
 
     level: 6
-
-    reportUnmatchedIgnoredErrors: false
-
-    ignoreErrors:
-        - '#Property AshAllenDesign\\ConfigValidator\\Services\\ValidationRepository\:\:\$rules has unknown class Illuminate\\Contracts\\Validation\\ValidationRule as its type.#'
-        - '#Property AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:\$rules has unknown class Illuminate\\Contracts\\Validation\\ValidationRule as its type.#'
-        - '#Parameter \$rules of method AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:rules\(\) has invalid type Illuminate\\Contracts\\Validation\\ValidationRule.#'
-        - '#Method AshAllenDesign\\ConfigValidator\\Services\\Rule\:\:getRules\(\) has invalid return type Illuminate\\Contracts\\Validation\\ValidationRule.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,3 +7,8 @@ parameters:
         - src
 
     level: 6
+
+    reportUnmatchedIgnoredErrors: false
+
+    ignoreErrors:
+        - '#Parameter #1 $view of function view expects view-string|null, string given. #'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,5 +9,5 @@ parameters:
     level: 6
 
     ignoreErrors:
-
-    checkMissingIterableValueType: false
+        - identifier: missingType.iterableValue
+        - '#Parameter \#1 \$view of function view expects view-string\|null, string given.#'

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,4 +11,4 @@ parameters:
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:
-        - '#Parameter \#1 \$view of function view expects view-string\|null, string given. #'
+        - '#Parameter \#1 \$view of function view expects view-string\|null, string given.#'

--- a/src/Console/Commands/ValidateConfigCommand.php
+++ b/src/Console/Commands/ValidateConfigCommand.php
@@ -70,6 +70,7 @@ class ValidateConfigCommand extends Command
         }
 
         if (! empty($this->configValidator->errors())) {
+            /** @phpstan-ignore-next-line argument.type */
             render(view('config-validator::validate-config', [
                 'allErrors' => $this->configValidator->errors(),
             ]));

--- a/src/Console/Commands/ValidateConfigCommand.php
+++ b/src/Console/Commands/ValidateConfigCommand.php
@@ -70,7 +70,6 @@ class ValidateConfigCommand extends Command
         }
 
         if (! empty($this->configValidator->errors())) {
-            /** @phpstan-ignore-next-line argument.type */
             render(view('config-validator::validate-config', [
                 'allErrors' => $this->configValidator->errors(),
             ]));

--- a/src/Console/Commands/ValidateConfigCommand.php
+++ b/src/Console/Commands/ValidateConfigCommand.php
@@ -88,7 +88,7 @@ class ValidateConfigCommand extends Command
      * inputs to an array of strings that can be
      * passed to the ConfigValidator object.
      *
-     * @return array
+     * @return string[]
      */
     private function determineFilesToValidate(): array
     {

--- a/src/Facades/ConfigValidator.php
+++ b/src/Facades/ConfigValidator.php
@@ -8,7 +8,7 @@ use RuntimeException;
 /**
  * @method static void run()
  * @method static ConfigValidator throwExceptionOnFailure()
- * @method static array errors()
+ * @method static array<string,string[]> errors()
  *
  * @see \AshAllenDesign\ConfigValidator\Services\ConfigValidator
  */

--- a/src/Facades/ConfigValidator.php
+++ b/src/Facades/ConfigValidator.php
@@ -18,8 +18,6 @@ class ConfigValidator extends Facade
      * Get the registered name of the component.
      *
      * @return string
-     *
-     * @throws RuntimeException
      */
     protected static function getFacadeAccessor(): string
     {

--- a/src/Services/ConfigValidator.php
+++ b/src/Services/ConfigValidator.php
@@ -24,7 +24,7 @@ class ConfigValidator
     /**
      * An array of the validation error messages.
      *
-     * @var array
+     * @var array<string,string[]>
      */
     private array $errors = [];
 
@@ -49,7 +49,7 @@ class ConfigValidator
     /**
      * Return the validation error messages.
      *
-     * @return array
+     * @return array<string,string[]>
      */
     public function errors(): array
     {
@@ -74,7 +74,7 @@ class ConfigValidator
      * Handle the loading of the config validation files
      * and then validate the config.
      *
-     * @param  array  $configFiles
+     * @param  string[]  $configFiles
      * @param  string|null  $validationFolderPath
      * @return bool
      *

--- a/src/Services/Rule.php
+++ b/src/Services/Rule.php
@@ -3,7 +3,6 @@
 namespace AshAllenDesign\ConfigValidator\Services;
 
 use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
 
 class Rule
 {
@@ -23,7 +22,7 @@ class Rule
     /**
      * The validation used for validating the config field.
      *
-     * @var array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>
+     * @var array<string|\Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Validation\Rule|Closure>
      */
     private array $rules = [];
 
@@ -111,7 +110,7 @@ class Rule
     /**
      * Get the validation rules set within this rule.
      *
-     * @return array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>
+     * @return array<string||\Illuminate\Validation\Rule|Closure>
      */
     public function getRules(): array
     {

--- a/src/Services/Rule.php
+++ b/src/Services/Rule.php
@@ -63,7 +63,7 @@ class Rule
     /**
      * Set the rules used for validating the config.
      *
-     * @param  array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>  $rules
+     * @param  array<string|\Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Validation\Rule|Closure>  $rules
      * @return $this
      */
     public function rules(array $rules): self
@@ -110,7 +110,7 @@ class Rule
     /**
      * Get the validation rules set within this rule.
      *
-     * @return array<string||\Illuminate\Validation\Rule|Closure>
+     * @return array<string|\Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Validation\Rule|Closure>
      */
     public function getRules(): array
     {

--- a/src/Services/Rule.php
+++ b/src/Services/Rule.php
@@ -2,6 +2,9 @@
 
 namespace AshAllenDesign\ConfigValidator\Services;
 
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
 class Rule
 {
     public const ENV_PRODUCTION = 'production';
@@ -20,7 +23,7 @@ class Rule
     /**
      * The validation used for validating the config field.
      *
-     * @var array
+     * @var array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>
      */
     private array $rules = [];
 
@@ -28,12 +31,12 @@ class Rule
      * The custom messages being used when validating the
      * config field.
      *
-     * @var array
+     * @var array<string,string>
      */
     private array $messages = [];
 
     /**
-     * @var array
+     * @var string[]
      */
     private array $environments = [];
 
@@ -61,7 +64,7 @@ class Rule
     /**
      * Set the rules used for validating the config.
      *
-     * @param  array  $rules
+     * @param  array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>  $rules
      * @return $this
      */
     public function rules(array $rules): self
@@ -75,7 +78,7 @@ class Rule
      * Set the custom messages used when validating the
      * config.
      *
-     * @param  array  $messages
+     * @param  array<string,string>  $messages
      * @return $this
      */
     public function messages(array $messages): self
@@ -85,6 +88,9 @@ class Rule
         return $this;
     }
 
+    /**
+     * @param string[] $environments
+     */
     public function environments(array $environments): self
     {
         $this->environments = array_merge($this->environments, $environments);
@@ -105,7 +111,7 @@ class Rule
     /**
      * Get the validation rules set within this rule.
      *
-     * @return array
+     * @return array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>
      */
     public function getRules(): array
     {
@@ -115,7 +121,7 @@ class Rule
     /**
      * Get the validation messages set within this rule.
      *
-     * @return array
+     * @return array<string,string>
      */
     public function getMessages(): array
     {
@@ -125,7 +131,7 @@ class Rule
     /**
      * Get the app environments set within this rule.
      *
-     * @return array
+     * @return string[]
      */
     public function getEnvironments(): array
     {

--- a/src/Services/ValidationRepository.php
+++ b/src/Services/ValidationRepository.php
@@ -3,7 +3,6 @@
 namespace AshAllenDesign\ConfigValidator\Services;
 
 use Closure;
-use Illuminate\Contracts\Validation\ValidationRule;
 
 class ValidationRepository
 {
@@ -19,7 +18,7 @@ class ValidationRepository
      * An array of rules that are to be used for validating
      * the config values.
      *
-     * @var array<string,array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>>
+     * @var array<string,array<string|\Illuminate\Contracts\Validation\ValidationRule|\Illuminate\Validation\Rule|Closure>>
      */
     private array $rules = [];
 

--- a/src/Services/ValidationRepository.php
+++ b/src/Services/ValidationRepository.php
@@ -2,13 +2,16 @@
 
 namespace AshAllenDesign\ConfigValidator\Services;
 
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
 class ValidationRepository
 {
     /**
      * An array of the config values that are being
      * validated.
      *
-     * @var array
+     * @var array<string,mixed>
      */
     private array $configValues = [];
 
@@ -16,7 +19,7 @@ class ValidationRepository
      * An array of rules that are to be used for validating
      * the config values.
      *
-     * @var array
+     * @var array<string,array<string|ValidationRule|\Illuminate\Validation\Rule|Closure>>
      */
     private array $rules = [];
 
@@ -24,7 +27,7 @@ class ValidationRepository
      * An array of custom messages that are to be used when
      * validating the config values.
      *
-     * @var array
+     * @var array<string,string>
      */
     private array $messages = [];
 
@@ -65,7 +68,7 @@ class ValidationRepository
      * Return the class' rules, config values and messages
      * as an array.
      *
-     * @return array
+     * @return array<string,mixed>
      */
     public function asArray(): array
     {
@@ -115,7 +118,7 @@ class ValidationRepository
      *
      * @param  string  $configKey
      * @param  Rule  $rule
-     * @return array
+     * @return array<string,mixed>
      */
     private function hydrateConfigValueArray(string $configKey, Rule $rule): array
     {

--- a/src/Traits/LoadsConfigValidationFiles.php
+++ b/src/Traits/LoadsConfigValidationFiles.php
@@ -13,9 +13,9 @@ trait LoadsConfigValidationFiles
      * Get all of the configuration validation files that
      * are set.
      *
-     * @param  array  $configFiles
+     * @param  string[]  $configFiles
      * @param  string|null  $validationFolderPath
-     * @return array
+     * @return array<string,string>
      *
      * @throws DirectoryNotFoundException
      * @throws NoValidationFilesFoundException
@@ -90,7 +90,7 @@ trait LoadsConfigValidationFiles
      * ['cache', 'auth'] were passed in, we would
      * return ['cache.php', 'auth.php'].
      *
-     * @param  array  $configFiles
+     * @param  string[]  $configFiles
      * @return string[]
      */
     protected function determineFilesToRead(array $configFiles = []): array


### PR DESCRIPTION
This PR migrates from `nunomaduro/larastan` to `larastan/larastan`.

It also drops support for v1 and v2 of the previous package. We now only support v2 and v3 of the newer package 🙂